### PR TITLE
Enable auto-height grids

### DIFF
--- a/Grid/GridType.php
+++ b/Grid/GridType.php
@@ -73,7 +73,11 @@ class GridType extends AbstractGridType {
 		$view->vars['stingerSoftAggrid_js_var'] = 'stingerSoftAggrid' . $view->vars['aggrid_js_id'];
 		$view->vars['ajax_url'] = $gridOptions['ajax_url'];
 		$view->vars['dataMode'] = $gridOptions['dataMode'];
-		$gridOptions['attr']['style'] = 'height: ' . $gridOptions['height'];
+		if(!$gridOptions['autoHeight']) {
+			$gridOptions['attr']['style'] = 'height: ' . $gridOptions['height'];
+		} else {
+			$view->vars['domLayout'] = 'autoHeight';
+		}
 		$gridOptions['attr']['class'] = $gridOptions['theme'];
 		$view->vars['attr'] = $gridOptions['attr'];
 
@@ -243,6 +247,9 @@ class GridType extends AbstractGridType {
 			}
 			return $value;
 		});
+
+		$resolver->setDefault('autoHeight', false);
+		$resolver->setAllowedTypes('autoHeight', 'bool');
 
 		$resolver->setDefault('sideBar', false);
 		$resolver->setAllowedValues('sideBar', static function ($valueToCheck) {

--- a/Resources/views/Grid/grid_options.js.twig
+++ b/Resources/views/Grid/grid_options.js.twig
@@ -53,6 +53,9 @@
 	{% if grid.vars.paginationAutoPageSize is defined and grid.vars.suppressPaginationPanel is not same as(null) %}
 		, suppressPaginationPanel: {{ grid.vars.paginationAutoPageSize|json_encode|raw }}
 	{% endif %}
+	{% if grid.vars.domLayout is defined and grid.vars.domLayout %}
+		, domLayout: {{ grid.vars.domLayout|json_encode|raw }}
+	{% endif %}
 	{% if grid.vars.dataMode == 'inline' %}
 		, rowData: {{ grid.inlineData|raw }}
 	{% endif %}


### PR DESCRIPTION
Added a new grid option `autoHeight` (default `false`). 

In case `autoHeight` is `true`, the grid option `height` is ignored and no height attribute is added to the style attribute of the grid container. Instead the `domLayout` property of the grid is set to `autoHeight`, allowing the grid to calculate its height automatically depending on the size of the rows being displayed.

See https://www.ag-grid.com/javascript-grid-width-and-height/#auto-height