### PR TITLE
Customize encoded JSON data via HTTP GET request

### DIFF
--- a/Resources/public/ts/StingerConfiguration.ts
+++ b/Resources/public/ts/StingerConfiguration.ts
@@ -1,6 +1,7 @@
 export class StingerConfiguration {
     attr: any
     ajaxUrl?: any
+    ajaxData?: object
     autoResizeFixedWidthColumns: any
     autoResizeManuallyResizedColumns: any
     autosizeColumnsButton: any

--- a/Resources/public/ts/StingerSoftAggrid.ts
+++ b/Resources/public/ts/StingerSoftAggrid.ts
@@ -110,7 +110,8 @@ export class StingerSoftAggrid {
         return jQuery.getJSON(this.options.stinger.ajaxUrl, {
             'agGrid': {
                 'gridId': '#' + that.gridId
-            }
+            },
+            'data': this.options.stinger.ajaxData
         }, function (data) {
             that.api.setRowData(data.items);
         });


### PR DESCRIPTION
In order to process and customize the encoded JSON data from the server using an HTTP GET request, it would be beneficial if data of specific data structures could be transferred to the backend.