### PR TITLE
Customize the configuration to set and use grid features using the appropriate aggrid license

### DIFF
--- a/Resources/public/ts/react/GridComponent.tsx
+++ b/Resources/public/ts/react/GridComponent.tsx
@@ -12,6 +12,7 @@ import {GridConfiguration} from 'stingersoftaggrid/ts/GridConfiguration';
 import type {BazingaTranslator} from 'bazinga-translator';
 import "./GridComponent.scss";
 import {NavigateFunction} from "react-router-dom";
+import {LicenseManager} from "@ag-grid-enterprise/core";
 
 ModuleRegistry.registerModules([ClientSideRowModelModule, RowGroupingModule, StatusBarModule, SideBarModule, SetFilterModule]);
 declare var Translator: BazingaTranslator;
@@ -110,6 +111,9 @@ export class GridComponent extends React.Component<IProps, IState> {
     processConfiguration(configuration) {
         if (this.additionalAjaxRequestBody) {
             configuration.stinger.additionalAjaxRequestBody = this.additionalAjaxRequestBody;
+        }
+        if (typeof configuration.stinger.enterpriseLicense === "string" && configuration.stinger.enterpriseLicense.length > 0) {
+            LicenseManager.setLicenseKey(configuration.stinger.enterpriseLicense)
         }
         StingerSoftAggrid.processJsonConfiguration(configuration);
         return configuration;


### PR DESCRIPTION
This feature makes it possible, if available, to pass a license key provided by Aggrid via the associated configurations of the bundle.